### PR TITLE
v2.0.5: Updated Ban List Endpoints Return Values

### DIFF
--- a/src/main/kotlin/com/rtomyj/skc/constant/DBQueryConstants.kt
+++ b/src/main/kotlin/com/rtomyj/skc/constant/DBQueryConstants.kt
@@ -9,7 +9,7 @@ object DBQueryConstants {
 				" FROM card_info" +
 				WHERE_CARD_NUMBER_IS_CARD_ID
 
-	const val GET_BAN_LIST_BY_STATUS = "SELECT card_name, monster_type, card_color, card_effect, card_number, card_attribute" +
+	const val GET_BAN_LIST_BY_STATUS = "SELECT card_name, monster_type, card_color, card_effect, card_number, card_attribute, monster_association" +
 			" FROM ban_list_info" +
 			" WHERE ban_status = :status" +
 			" AND ban_list_date = :date" +

--- a/src/main/kotlin/com/rtomyj/skc/dao/implementation/BanListJDBCDao.kt
+++ b/src/main/kotlin/com/rtomyj/skc/dao/implementation/BanListJDBCDao.kt
@@ -1,5 +1,6 @@
 package com.rtomyj.skc.dao.implementation
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.rtomyj.skc.constant.DBQueryConstants
 import com.rtomyj.skc.dao.BanListDao
 import com.rtomyj.skc.enums.BanListCardStatus
@@ -7,6 +8,7 @@ import com.rtomyj.skc.model.banlist.BanListDates
 import com.rtomyj.skc.model.banlist.CardBanListStatus
 import com.rtomyj.skc.model.banlist.CardsPreviousBanListStatus
 import com.rtomyj.skc.model.card.Card
+import com.rtomyj.skc.model.card.MonsterAssociation
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -24,6 +26,7 @@ import java.text.SimpleDateFormat
 class BanListJDBCDao @Autowired constructor(
     private val jdbcNamedTemplate: NamedParameterJdbcTemplate,
     @Qualifier("dbSimpleDateFormat") private val dateFormat: SimpleDateFormat,
+    val objectMapper: ObjectMapper
 ) : BanListDao {
     companion object {
         private val log: Logger = LoggerFactory.getLogger(this::class.java)
@@ -48,10 +51,10 @@ class BanListJDBCDao @Autowired constructor(
                         row.getString(3),
                         row.getString(6),
                         row.getString(4)
-
                     )
                         .apply {
                             monsterType = row.getString(2)
+                            monsterAssociation = MonsterAssociation.parseDBString(row.getString(7), objectMapper)
                         }
                 )
             }

--- a/src/main/kotlin/com/rtomyj/skc/dao/implementation/BanListJDBCDao.kt
+++ b/src/main/kotlin/com/rtomyj/skc/dao/implementation/BanListJDBCDao.kt
@@ -176,11 +176,12 @@ class BanListJDBCDao @Autowired constructor(
         }
 
         val query = "select card_name, monster_type, card_color, card_effect, new_list.card_number, card_attribute, monster_association " +
-                "from (select * from ban_list_info where ban_list_date = '2022-02-07' and ban_status = 'forbidden') as new_list " +
+                "from (select * from ban_list_info where ban_list_date = :newBanList and ban_status = :status) as new_list " +
                 "left join " +
-                "(select card_number, ban_status from ban_list_info where ban_list_date = '2021-10-01' and ban_status = 'forbidden') as old_list " +
+                "(select card_number, ban_status from ban_list_info where ban_list_date = :oldBanList and ban_status = :status) as old_list " +
                 "on new_list.card_number = old_list.card_number " +
-                "where old_list.card_number is NULL"
+                "where old_list.card_number is NULL " +
+                "ORDER BY color_id, card_name"
 
         val sqlParams = MapSqlParameterSource()
         sqlParams.addValue("status", status.toString())

--- a/src/main/kotlin/com/rtomyj/skc/dao/implementation/JDBCDao.kt
+++ b/src/main/kotlin/com/rtomyj/skc/dao/implementation/JDBCDao.kt
@@ -13,7 +13,7 @@ import com.rtomyj.skc.model.banlist.CardBanListStatus
 import com.rtomyj.skc.model.card.Card
 import com.rtomyj.skc.model.card.CardBrowseCriteria
 import com.rtomyj.skc.model.card.CardBrowseResults
-import com.rtomyj.skc.model.card.MonsterAssociation.Companion.parseDBString
+import com.rtomyj.skc.model.card.MonsterAssociation
 import com.rtomyj.skc.model.stats.DatabaseStats
 import com.rtomyj.skc.model.stats.MonsterTypeStats
 import org.slf4j.LoggerFactory
@@ -100,7 +100,7 @@ class JDBCDao @Autowired constructor(
                         monsterType = row.getString(5)
                         monsterAttack = row.getObject(6, Int::class.javaObjectType)
                         monsterDefense = row.getObject(7, Int::class.javaObjectType)
-                        monsterAssociation = parseDBString(row.getString(8), objectMapper)
+                        monsterAssociation = MonsterAssociation.parseDBString(row.getString(8), objectMapper)
                     }
             }
             null
@@ -373,7 +373,7 @@ class JDBCDao @Autowired constructor(
             )
                 .apply {
                     this.monsterType = row.getString(BrowseQueryDefinition.MONSTER_TYPE.toString())
-                    this.monsterAssociation = parseDBString(
+                    this.monsterAssociation = MonsterAssociation.parseDBString(
                         row.getString(BrowseQueryDefinition.MONSTER_ASSOCIATION.toString()), objectMapper
                     )
                 }

--- a/src/main/kotlin/com/rtomyj/skc/model/banlist/BanListDate.kt
+++ b/src/main/kotlin/com/rtomyj/skc/model/banlist/BanListDate.kt
@@ -50,7 +50,7 @@ data class BanListDate(
         this.add(
             WebMvcLinkBuilder.linkTo(
                 WebMvcLinkBuilder.methodOn(BANNED_CARDS_CONTROLLER_CLASS)
-                    .getBannedCards(banListDateStr, false, true)
+                    .getBannedCards(banListDateStr, true, false)
             )
                 .withRel("Ban List Content")
         )

--- a/src/main/kotlin/com/rtomyj/skc/model/banlist/BanListNewContent.kt
+++ b/src/main/kotlin/com/rtomyj/skc/model/banlist/BanListNewContent.kt
@@ -83,6 +83,13 @@ data class BanListNewContent(
 
     override fun setLinks() {
         setSelfLink()
+        newForbidden
+            .forEach(CardsPreviousBanListStatus::setLinks)
+        newLimited
+            .forEach(CardsPreviousBanListStatus::setLinks)
+        newSemiLimited
+            .forEach(CardsPreviousBanListStatus::setLinks)
+
         this.add(
             WebMvcLinkBuilder.linkTo(
                 WebMvcLinkBuilder.methodOn(banListController).getBannedCards(listRequested, false, true)

--- a/src/main/kotlin/com/rtomyj/skc/model/banlist/BanListNewContent.kt
+++ b/src/main/kotlin/com/rtomyj/skc/model/banlist/BanListNewContent.kt
@@ -94,8 +94,5 @@ data class BanListNewContent(
                     .getNewlyRemovedContentForBanList(listRequested)
             ).withRel("Ban List Removed Content")
         )
-        HateoasLinks.setLinks(newForbidden)
-        HateoasLinks.setLinks(newLimited)
-        HateoasLinks.setLinks(newSemiLimited)
     }
 }

--- a/src/main/kotlin/com/rtomyj/skc/model/banlist/BanListRemovedContent.kt
+++ b/src/main/kotlin/com/rtomyj/skc/model/banlist/BanListRemovedContent.kt
@@ -68,6 +68,5 @@ data class BanListRemovedContent(
                 WebMvcLinkBuilder.methodOn(diffController).getNewlyAddedContentForBanList(listRequested)
             ).withRel("Ban List New Content")
         )
-        HateoasLinks.setLinks(removedCards)
     }
 }

--- a/src/main/kotlin/com/rtomyj/skc/model/banlist/BanListRemovedContent.kt
+++ b/src/main/kotlin/com/rtomyj/skc/model/banlist/BanListRemovedContent.kt
@@ -58,6 +58,10 @@ data class BanListRemovedContent(
 
     override fun setLinks() {
         setSelfLink()
+
+        removedCards
+            .forEach(CardsPreviousBanListStatus::setLinks)
+
         this.add(
             WebMvcLinkBuilder.linkTo(
                 WebMvcLinkBuilder.methodOn(banListController).getBannedCards(listRequested, false, true)

--- a/src/main/kotlin/com/rtomyj/skc/model/banlist/CardsPreviousBanListStatus.kt
+++ b/src/main/kotlin/com/rtomyj/skc/model/banlist/CardsPreviousBanListStatus.kt
@@ -27,4 +27,7 @@ data class CardsPreviousBanListStatus(
     )
     val previousBanStatus: String
 ) : RepresentationModel<CardsPreviousBanListStatus?>() {
+    fun setLinks() {
+        card.setLinks()
+    }
 }

--- a/src/main/kotlin/com/rtomyj/skc/model/banlist/CardsPreviousBanListStatus.kt
+++ b/src/main/kotlin/com/rtomyj/skc/model/banlist/CardsPreviousBanListStatus.kt
@@ -4,6 +4,7 @@ import com.rtomyj.skc.Open
 import com.rtomyj.skc.constant.SwaggerConstants
 import com.rtomyj.skc.controller.card.CardController
 import com.rtomyj.skc.model.HateoasLinks
+import com.rtomyj.skc.model.card.Card
 import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.hateoas.RepresentationModel
 import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder
@@ -15,41 +16,15 @@ import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder
 @Open
 data class CardsPreviousBanListStatus(
     @Schema(
-        implementation = CardsPreviousBanListStatus::class,
-        description = SwaggerConstants.CARD_ID_DESCRIPTION, 
+        implementation = Card::class,
+        description = "Card details",
     )
-    val cardId: String,
+    val card: Card,
 
     @Schema(
-        implementation = CardsPreviousBanListStatus::class,
-        description = SwaggerConstants.CARD_NAME_DESCRIPTION,
-    )
-    val cardName: String,
-
-    @Schema(
-        implementation = CardsPreviousBanListStatus::class,
+        implementation = String::class,
         description = "The previous ban status the card had when compared to current ban list.",
     )
     val previousBanStatus: String
-) : RepresentationModel<CardsPreviousBanListStatus?>(), HateoasLinks {
-
-    companion object {
-        private val controllerClass = CardController::class.java
-    }
-
-
-    override fun setSelfLink() {
-        this.add(
-            WebMvcLinkBuilder.linkTo(
-                WebMvcLinkBuilder.methodOn(controllerClass).getCard(
-                    cardId, false
-                )
-            ).withSelfRel()
-        )
-    }
-
-
-    override fun setLinks() {
-        setSelfLink()
-    }
+) : RepresentationModel<CardsPreviousBanListStatus?>() {
 }

--- a/src/main/kotlin/com/rtomyj/skc/model/card/MonsterAssociation.kt
+++ b/src/main/kotlin/com/rtomyj/skc/model/card/MonsterAssociation.kt
@@ -76,6 +76,13 @@ class MonsterAssociation(
                 .filter { it != null }
                 .forEach { it!!.transformMonsterLinkRating() }
         }
+
+
+        /**
+         * Calls [.transformMonsterLinkRating] on a card
+         * @param card card whose link rating should be transformed
+         */
+        fun transformMonsterLinkRating(card: Card) = card.monsterAssociation?.transformMonsterLinkRating()
     }
 
 

--- a/src/main/kotlin/com/rtomyj/skc/service/banlist/BannedCardsService.kt
+++ b/src/main/kotlin/com/rtomyj/skc/service/banlist/BannedCardsService.kt
@@ -2,12 +2,12 @@ package com.rtomyj.skc.service.banlist
 
 import com.rtomyj.skc.constant.ErrConstants
 import com.rtomyj.skc.dao.BanListDao
-import com.rtomyj.skc.dao.Dao
 import com.rtomyj.skc.enums.BanListCardStatus
 import com.rtomyj.skc.exception.ErrorType
 import com.rtomyj.skc.exception.YgoException
 import com.rtomyj.skc.model.banlist.BanListInstance
 import com.rtomyj.skc.model.card.Card
+import com.rtomyj.skc.model.card.MonsterAssociation
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -58,6 +58,10 @@ class BannedCardsService @Autowired constructor(
 			if (saveBandwidth) {
 				Card.trimEffects(this)
 			}
+
+			MonsterAssociation.transformMonsterLinkRating(this.forbidden)
+			MonsterAssociation.transformMonsterLinkRating(this.limited)
+			MonsterAssociation.transformMonsterLinkRating(this.semiLimited)
 		}
 
 		return banListInstance

--- a/src/main/kotlin/com/rtomyj/skc/service/banlist/DiffService.kt
+++ b/src/main/kotlin/com/rtomyj/skc/service/banlist/DiffService.kt
@@ -7,6 +7,7 @@ import com.rtomyj.skc.exception.ErrorType
 import com.rtomyj.skc.exception.YgoException
 import com.rtomyj.skc.model.banlist.BanListNewContent
 import com.rtomyj.skc.model.banlist.BanListRemovedContent
+import com.rtomyj.skc.model.card.MonsterAssociation
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
@@ -39,6 +40,10 @@ class DiffService @Autowired constructor(
         val limited = banListDao.getNewContentOfBanList(banListStartDate, BanListCardStatus.LIMITED)
         val semiLimited = banListDao.getNewContentOfBanList(banListStartDate, BanListCardStatus.SEMI_LIMITED)
 
+        forbidden.forEach { MonsterAssociation.transformMonsterLinkRating(it.card) }
+        limited.forEach { MonsterAssociation.transformMonsterLinkRating(it.card) }
+        semiLimited.forEach { MonsterAssociation.transformMonsterLinkRating(it.card) }
+
         val newCardsMeta = BanListNewContent(
             banListStartDate,
             getPreviousBanListDate(banListStartDate),
@@ -63,6 +68,8 @@ class DiffService @Autowired constructor(
         val removedCards = banListDao.getRemovedContentOfBanList(
             banListStartDate
         )
+
+        removedCards.forEach { MonsterAssociation.transformMonsterLinkRating(it.card) }
 
         // builds meta data object for removed cards request
         val removedCardsMeta = BanListRemovedContent(

--- a/src/test/kotlin/com/rtomyj/skc/service/banlist/BanListDatesServiceTest.kt
+++ b/src/test/kotlin/com/rtomyj/skc/service/banlist/BanListDatesServiceTest.kt
@@ -63,7 +63,7 @@ class BanListDatesServiceTest {
             Assertions.assertNotNull(dates[0].links)
 
             Assertions.assertNotNull(dates[0].links.getLink("Ban List Content"))
-            Assertions.assertEquals("/ban_list/2020-01-20/cards?saveBandwidth=false&allInfo=true"
+            Assertions.assertEquals("/ban_list/2020-01-20/cards?saveBandwidth=true&allInfo=false"
                 , dates[0].links.getLink("Ban List Content").get().href)
 
             Assertions.assertNotNull(dates[0].links.getLink("Ban List New Content"))

--- a/src/test/kotlin/com/rtomyj/skc/service/banlist/BannedCardsServiceTest.kt
+++ b/src/test/kotlin/com/rtomyj/skc/service/banlist/BannedCardsServiceTest.kt
@@ -303,14 +303,14 @@ class BannedCardsServiceTest {
         private fun assertFetchAllInfoValues(banListInstance: BanListInstance, fetchAllInfo: Boolean) {
             if (fetchAllInfo) {
                 Assertions.assertNotNull(banListInstance.newContent)
-                Assertions.assertEquals(TestConstants.STRATOS_NAME, banListInstance.newContent!!.newForbidden[0].cardName)
-                Assertions.assertEquals(TestConstants.A_HERO_LIVES_NAME, banListInstance.newContent!!.newLimited[0].cardName)
-                Assertions.assertEquals(TestConstants.D_MALICIOUS_NAME, banListInstance.newContent!!.newLimited[1].cardName)
+                Assertions.assertEquals(TestConstants.STRATOS_NAME, banListInstance.newContent!!.newForbidden[0].card.cardName)
+                Assertions.assertEquals(TestConstants.A_HERO_LIVES_NAME, banListInstance.newContent!!.newLimited[0].card.cardName)
+                Assertions.assertEquals(TestConstants.D_MALICIOUS_NAME, banListInstance.newContent!!.newLimited[1].card.cardName)
 
                 Assertions.assertNotNull(banListInstance.removedContent)
-                Assertions.assertEquals(TestConstants.STRATOS_NAME, banListInstance.removedContent!!.removedCards[0].cardName)
-                Assertions.assertEquals(TestConstants.A_HERO_LIVES_NAME, banListInstance.removedContent!!.removedCards[1].cardName)
-                Assertions.assertEquals(TestConstants.D_MALICIOUS_NAME, banListInstance.removedContent!!.removedCards[2].cardName)
+                Assertions.assertEquals(TestConstants.STRATOS_NAME, banListInstance.removedContent!!.removedCards[0].card.cardName)
+                Assertions.assertEquals(TestConstants.A_HERO_LIVES_NAME, banListInstance.removedContent!!.removedCards[1].card.cardName)
+                Assertions.assertEquals(TestConstants.D_MALICIOUS_NAME, banListInstance.removedContent!!.removedCards[2].card.cardName)
             } else {
                 Assertions.assertNull(banListInstance.newContent)
                 Assertions.assertNull(banListInstance.removedContent)

--- a/src/test/kotlin/com/rtomyj/skc/service/banlist/DiffServiceTest.kt
+++ b/src/test/kotlin/com/rtomyj/skc/service/banlist/DiffServiceTest.kt
@@ -113,13 +113,13 @@ class DiffServiceTest {
             Assertions.assertEquals(0, newSemiLimitedCards.size)
 
             // validate correct data is returned in each list for each ban status
-            Assertions.assertEquals(TestConstants.STRATOS_ID, newForbiddenCards[0].cardId)
+            Assertions.assertEquals(TestConstants.STRATOS_ID, newForbiddenCards[0].card.cardID)
             Assertions.assertEquals("Limited", newForbiddenCards[0].previousBanStatus)
 
-            Assertions.assertEquals(TestConstants.A_HERO_LIVES_ID, newLimitedCards[0].cardId)
+            Assertions.assertEquals(TestConstants.A_HERO_LIVES_ID, newLimitedCards[0].card.cardID)
             Assertions.assertEquals("Unlimited", newLimitedCards[0].previousBanStatus)
 
-            Assertions.assertEquals(TestConstants.D_MALICIOUS_ID, newLimitedCards[1].cardId)
+            Assertions.assertEquals(TestConstants.D_MALICIOUS_ID, newLimitedCards[1].card.cardID)
             Assertions.assertEquals("Forbidden", newLimitedCards[1].previousBanStatus)
 
             // ensure self link is present
@@ -197,16 +197,16 @@ class DiffServiceTest {
             Assertions.assertEquals(3, removedCards.size)
 
             // ensure correct values are being returned in removedCards array
-            Assertions.assertEquals(TestConstants.STRATOS_ID, removedCards[0].cardId)
-            Assertions.assertEquals(TestConstants.STRATOS_NAME, removedCards[0].cardName)
+            Assertions.assertEquals(TestConstants.STRATOS_ID, removedCards[0].card.cardID)
+            Assertions.assertEquals(TestConstants.STRATOS_NAME, removedCards[0].card.cardID)
             Assertions.assertEquals("Forbidden", removedCards[0].previousBanStatus)
 
-            Assertions.assertEquals(TestConstants.A_HERO_LIVES_ID, removedCards[1].cardId)
-            Assertions.assertEquals(TestConstants.A_HERO_LIVES_NAME, removedCards[1].cardName)
+            Assertions.assertEquals(TestConstants.A_HERO_LIVES_ID, removedCards[1].card.cardID)
+            Assertions.assertEquals(TestConstants.A_HERO_LIVES_NAME, removedCards[1].card.cardID)
             Assertions.assertEquals("Limited", removedCards[1].previousBanStatus)
 
-            Assertions.assertEquals(TestConstants.D_MALICIOUS_ID, removedCards[2].cardId)
-            Assertions.assertEquals(TestConstants.D_MALICIOUS_NAME, removedCards[2].cardName)
+            Assertions.assertEquals(TestConstants.D_MALICIOUS_ID, removedCards[2].card.cardID)
+            Assertions.assertEquals(TestConstants.D_MALICIOUS_NAME, removedCards[2].card.cardID)
             Assertions.assertEquals("Semi-Limited", removedCards[2].previousBanStatus)
 
             // ensure self link is present

--- a/src/test/kotlin/com/rtomyj/skc/service/banlist/DiffServiceTest.kt
+++ b/src/test/kotlin/com/rtomyj/skc/service/banlist/DiffServiceTest.kt
@@ -123,17 +123,17 @@ class DiffServiceTest {
             Assertions.assertEquals("Forbidden", newLimitedCards[1].previousBanStatus)
 
             // ensure self link is present
-            Assertions.assertNotNull(newForbiddenCards[0].links.getLink("self"))
-            Assertions.assertNotNull(newLimitedCards[0].links.getLink("self"))
-            Assertions.assertNotNull(newLimitedCards[1].links.getLink("self"))
+            Assertions.assertNotNull(newForbiddenCards[0].card.links.getLink("self"))
+            Assertions.assertNotNull(newLimitedCards[0].card.links.getLink("self"))
+            Assertions.assertNotNull(newLimitedCards[1].card.links.getLink("self"))
 
             // ensure href is as expected
-            Assertions.assertEquals("/card/${TestConstants.STRATOS_ID}?allInfo=false"
-                , newForbiddenCards[0].links.getLink("self").get().href)
-            Assertions.assertEquals("/card/${TestConstants.A_HERO_LIVES_ID}?allInfo=false"
-                , newLimitedCards[0].links.getLink("self").get().href)
-            Assertions.assertEquals("/card/${TestConstants.D_MALICIOUS_ID}?allInfo=false"
-                , newLimitedCards[1].links.getLink("self").get().href)
+            Assertions.assertEquals("/card/${TestConstants.STRATOS_ID}?allInfo=true"
+                , newForbiddenCards[0].card.links.getLink("self").get().href)
+            Assertions.assertEquals("/card/${TestConstants.A_HERO_LIVES_ID}?allInfo=true"
+                , newLimitedCards[0].card.links.getLink("self").get().href)
+            Assertions.assertEquals("/card/${TestConstants.D_MALICIOUS_ID}?allInfo=true"
+                , newLimitedCards[1].card.links.getLink("self").get().href)
 
 
             // ensure mocks are called appropriate number of times
@@ -198,34 +198,34 @@ class DiffServiceTest {
 
             // ensure correct values are being returned in removedCards array
             Assertions.assertEquals(TestConstants.STRATOS_ID, removedCards[0].card.cardID)
-            Assertions.assertEquals(TestConstants.STRATOS_NAME, removedCards[0].card.cardID)
+            Assertions.assertEquals(TestConstants.STRATOS_NAME, removedCards[0].card.cardName)
             Assertions.assertEquals("Forbidden", removedCards[0].previousBanStatus)
 
             Assertions.assertEquals(TestConstants.A_HERO_LIVES_ID, removedCards[1].card.cardID)
-            Assertions.assertEquals(TestConstants.A_HERO_LIVES_NAME, removedCards[1].card.cardID)
+            Assertions.assertEquals(TestConstants.A_HERO_LIVES_NAME, removedCards[1].card.cardName)
             Assertions.assertEquals("Limited", removedCards[1].previousBanStatus)
 
             Assertions.assertEquals(TestConstants.D_MALICIOUS_ID, removedCards[2].card.cardID)
-            Assertions.assertEquals(TestConstants.D_MALICIOUS_NAME, removedCards[2].card.cardID)
+            Assertions.assertEquals(TestConstants.D_MALICIOUS_NAME, removedCards[2].card.cardName)
             Assertions.assertEquals("Semi-Limited", removedCards[2].previousBanStatus)
 
             // ensure self link is present
-            Assertions.assertNotNull(removedCards[0].links.getLink("self"))
-            Assertions.assertNotNull(removedCards[1].links.getLink("self"))
-            Assertions.assertNotNull(removedCards[2].links.getLink("self"))
+            Assertions.assertNotNull(removedCards[0].card.links.getLink("self"))
+            Assertions.assertNotNull(removedCards[1].card.links.getLink("self"))
+            Assertions.assertNotNull(removedCards[2].card.links.getLink("self"))
 
             // ensure href is as expected
             Assertions.assertEquals(
-                "/card/${TestConstants.STRATOS_ID}?allInfo=false"
-                , removedCards[0].links.getLink("self").get().href
+                "/card/${TestConstants.STRATOS_ID}?allInfo=true"
+                , removedCards[0].card.links.getLink("self").get().href
             )
             Assertions.assertEquals(
-                "/card/${TestConstants.A_HERO_LIVES_ID}?allInfo=false"
-                , removedCards[1].links.getLink("self").get().href
+                "/card/${TestConstants.A_HERO_LIVES_ID}?allInfo=true"
+                , removedCards[1].card.links.getLink("self").get().href
             )
             Assertions.assertEquals(
-                "/card/${TestConstants.D_MALICIOUS_ID}?allInfo=false"
-                , removedCards[2].links.getLink("self").get().href
+                "/card/${TestConstants.D_MALICIOUS_ID}?allInfo=true"
+                , removedCards[2].card.links.getLink("self").get().href
             )
 
 

--- a/src/test/resources/json-mock/BanListNewContent.json
+++ b/src/test/resources/json-mock/BanListNewContent.json
@@ -6,21 +6,47 @@
 	"numNewSemiLimited": 0,
 	"newForbidden": [
 		{
-			"cardId": "40044918",
-			"cardName": "Elemental HERO Stratos",
+			"card": {
+				"cardID": "40044918",
+				"cardName": "Elemental HERO Stratos",
+				"cardColor": "Effect",
+				"cardAttribute": "Wind",
+				"cardEffect": "When this card is Normal or Special Summoned: You can activate 1 of these effects.\n&bull; Destroy Spells/Traps on the field, up to the number of \"HERO\" monsters you control, except this card.\n&bull; Add 1 \"HERO\" monster from your Deck to your hand.",
+				"monsterType": "Warrior/Effect",
+				"monsterAssociation": {
+					"level": 4
+				},
+				"monsterAttack": 1800,
+				"monsterDefense": 300
+			},
 			"previousBanStatus": "Limited"
 		}
 	],
 	"newLimited": [
 		{
-			"cardId": "08949584",
-			"cardName": "A Hero Lives",
+			"card": {
+				"cardID": "08949584",
+				"cardName": "A Hero Lives",
+				"cardColor": "Spell",
+				"cardAttribute": "Spell",
+				"cardEffect": "If you control no face-up monsters: Pay half your LP; Special Summon 1 Level 4 or lower 'Elemental HERO' monster from your Deck."
+			},
 			"previousBanStatus": "Unlimited"
-		}
-		,
+		},
 		{
-			"cardId": "09411399",
-			"cardName": "Destiny HERO - Malicious",
+			"card": {
+				"cardID": "09411399",
+				"cardName": "Destiny HERO - Malicious",
+				"cardColor": "Effect",
+				"cardAttribute": "Dark",
+				"cardEffect": "You can banish this card from your GY; Special Summon 1 \"Destiny HERO - Malicious\" from your Deck.",
+				"monsterType": "Warrior/Effect",
+				"monsterAssociation": {
+					"level": 6
+				},
+				"monsterAttack": 800,
+				"monsterDefense": 800
+			},
 			"previousBanStatus": "Forbidden"
 		}
 	],

--- a/src/test/resources/json-mock/BanListRemovedContent.json
+++ b/src/test/resources/json-mock/BanListRemovedContent.json
@@ -4,18 +4,45 @@
 	"numRemoved": 3,
 	"removedCards": [
 		{
-			"cardId": "40044918",
-			"cardName": "Elemental HERO Stratos",
+			"card": {
+				"cardID": "40044918",
+				"cardName": "Elemental HERO Stratos",
+				"cardColor": "Effect",
+				"cardAttribute": "Wind",
+				"cardEffect": "When this card is Normal or Special Summoned: You can activate 1 of these effects.\n&bull; Destroy Spells/Traps on the field, up to the number of \"HERO\" monsters you control, except this card.\n&bull; Add 1 \"HERO\" monster from your Deck to your hand.",
+				"monsterType": "Warrior/Effect",
+				"monsterAssociation": {
+					"level": 4
+				},
+				"monsterAttack": 1800,
+				"monsterDefense": 300
+			},
 			"previousBanStatus": "Forbidden"
       },
       {
-			"cardId": "08949584",
-			"cardName": "A Hero Lives",
+		  "card": {
+			  "cardID": "08949584",
+			  "cardName": "A Hero Lives",
+			  "cardColor": "Spell",
+			  "cardAttribute": "Spell",
+			  "cardEffect": "If you control no face-up monsters: Pay half your LP; Special Summon 1 Level 4 or lower 'Elemental HERO' monster from your Deck."
+		  },
 			"previousBanStatus": "Limited"
       },
       {
-			"cardId": "09411399",
-			"cardName": "Destiny HERO - Malicious",
+		  "card": {
+			  "cardID": "09411399",
+			  "cardName": "Destiny HERO - Malicious",
+			  "cardColor": "Effect",
+			  "cardAttribute": "Dark",
+			  "cardEffect": "You can banish this card from your GY; Special Summon 1 \"Destiny HERO - Malicious\" from your Deck.",
+			  "monsterType": "Warrior/Effect",
+			  "monsterAssociation": {
+				  "level": 6
+			  },
+			  "monsterAttack": 800,
+			  "monsterDefense": 800
+		  },
 			"previousBanStatus": "Semi-Limited"
       }
    ]

--- a/src/test/resources/sql/data.sql
+++ b/src/test/resources/sql/data.sql
@@ -11,29 +11,37 @@ INSERT INTO card_colors(card_color)
 				, ('Spell')
 				, ('Trap');
 
+
 INSERT INTO cards(
 	card_number, color_id, card_name, card_attribute,
 	card_effect,
-	monster_type, monster_attack, monster_defense)
+	monster_type, monster_attack, monster_defense, monster_association)
 	VALUES (
 		'40044918', (select color_id from card_colors where card_color = 'Effect'), 'Elemental HERO Stratos', 'Wind',
 		'When this card is Normal or Special Summoned: You can activate 1 of these effects.
 &bull; You can destroy Spell/Trap Cards on the field, up to the number of "HERO" monsters you control, except this card.
 &bull; Add 1 "HERO" monster from your Deck to your hand.',
-		'Warrior/Effect', 1800, 300
-	)
-	, (
-	'08949584', (select color_id from card_colors where card_color = 'Spell'), 'A Hero Lives', 'Spell',
-	'If you control no face-up monsters: Pay half your LP; Special Summon 1 Level 4 or lower "Elemental HERO" monster from your Deck.'
-	, null, null, null
+		'Warrior/Effect', 1800, 300, '{"level": "4"}'
 	)
 	, (
 		'09411399', (select color_id from card_colors where card_color = 'Effect'), 'Destiny HERO - Malicious', 'Dark',
 		'You can banish this card from your GY; Special Summon 1 "Destiny HERO - Malicious" from your Deck.',
-		'Warrior/Effect', 800, 800
+		'Warrior/Effect', 800, 800, '{"level": "6"}'
 	);
 
+
+
+INSERT INTO cards (
+	card_number, color_id, card_name, card_attribute,
+	card_effect, property)
+    VALUES (
+        '08949584', (select color_id from card_colors where card_color = 'Spell'), 'A Hero Lives', 'Spell',
+        'If you control no face-up monsters: Pay half your LP; Special Summon 1 Level 4 or lower "Elemental HERO" monster from your Deck.'
+        , null
+    );
+
+
 INSERT INTO ban_lists(ban_list_date, card_number, ban_status)
-	VALUES('2015-11-09', '40044918', 'Forbidden')
+	VALUES ('2015-11-09', '40044918', 'Forbidden')
 	, ('2015-11-09', '08949584', 'Limited')
 	, ('2015-11-09', '09411399', 'Limited');

--- a/src/test/resources/sql/schema.sql
+++ b/src/test/resources/sql/schema.sql
@@ -7,13 +7,14 @@ CREATE TABLE card_colors
 
 CREATE TABLE cards
 (
-	card_number CHAR(8) NOT NULL,
+	card_number VARCHAR(8) NOT NULL,
 	color_id INT NOT NULL,
-	card_name VARCHAR(50) NOT NULL,
+	card_name VARCHAR(55) NOT NULL UNIQUE,
 	card_attribute VARCHAR(20) NOT NULL,
 	card_effect VARCHAR(1500),
+	property VARCHAR(15),
 	monster_type VARCHAR(35),
-	monster_association VARCHAR(70),
+	monster_association VARCHAR(80),
 	monster_attack INT,
 	monster_defense INT,
 	PRIMARY KEY(card_number),

--- a/src/test/resources/sql/views.sql
+++ b/src/test/resources/sql/views.sql
@@ -12,7 +12,7 @@ WHERE
 CREATE VIEW ban_list_info
 AS
 SELECT
-	card_name, monster_type, card_color, card_effect, card_attribute, card_info.card_number, ban_status, ban_list_date, color_id
+	card_name, monster_type, card_color, card_effect, card_attribute, card_info.card_number, ban_status, ban_list_date, color_id, monster_association
 FROM
 	card_info, ban_lists
 WHERE


### PR DESCRIPTION
## Changes
* Ban list new content, removed content and content all now return more info about the cards. This new info will allow UI to display a richer set of information for each database.
* Updated HATEOAS links for ban lists to UI can call endpoints with correct values
* https://github.com/ygo-skc/skc-api/issues/38: Updated SQL queries for ban list new/removed content to simplify them and also retrieve the data needed by new functionality